### PR TITLE
Update the JSON dependency

### DIFF
--- a/lokalise.gemspec
+++ b/lokalise.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'byebug', '>= 8.2'
   spec.add_runtime_dependency 'excon', '~> 0.40'
   spec.add_runtime_dependency 'hashie', '~> 2'
-  spec.add_runtime_dependency 'json', '~> 1.8'
+  spec.add_runtime_dependency 'json', '~> 2.0'
   spec.add_runtime_dependency 'rubyzip', '~> 1.0'
   spec.add_runtime_dependency 'slop', '~> 4.0'
 end


### PR DESCRIPTION
JSON 1.8.3 is not compatible with Ruby 2.4 and [fails to install the
gem](https://github.com/flori/json/issues/303). Updating to the latest version
of the JSON gem gives us greater support for the newer Ruby.