### PR TITLE
Update the zip file export URL

### DIFF
--- a/lib/lokalise.rb
+++ b/lib/lokalise.rb
@@ -97,7 +97,7 @@ module Lokalise
     end
 
     def download_zip
-      zip_url_on_server = "https://lokalise.co/#{@zip_path_on_server}"
+      zip_url_on_server = "https://s3-eu-west-1.amazonaws.com/lokalise-assets/#{@zip_path_on_server}"
       log "Downloading zip file from #{zip_url_on_server}"
       `curl --silent #{zip_url_on_server} > #{ZIP_FILE}`
     end


### PR DESCRIPTION
Lokalise have [recently made changes to their API download URL](https://lokalise.co/changes) to an Amazon S3 bucket. This was causing `bundle exec lokalise` to fail with an error "Zip::Error: Zip end of central directory signature not found".

Updating the download URL keeps us up to date with the latest API changes.