### PR TITLE
Allow to set "export_empty" and "filter" values

### DIFF
--- a/lib/lokalise.rb
+++ b/lib/lokalise.rb
@@ -35,6 +35,7 @@ module Lokalise
     property :language_fallback
     property :quiet
     property :verbose
+    property :filter, default 'translated'
     property :yaml_include_root
     property :export_empty, default: 'skip'
 
@@ -70,13 +71,12 @@ module Lokalise
           export_all: 1,
           type: self.output_format,
           use_original: '0',
-          filter: 'translated',
+          filter: self.filter,
           bundle_filename: '%PROJECT_NAME%-Locale.zip',
           bundle_structure: self.structure,
           export_empty: self.export_empty,
           yaml_include_root: boolean_to_binary[yaml_include_root]
       )
-      p body.pretty_inspect
 
       fetch_start = Time.now
       response = Excon.post 'https://lokalise.co/api/project/export',

--- a/lib/lokalise.rb
+++ b/lib/lokalise.rb
@@ -36,6 +36,7 @@ module Lokalise
     property :quiet
     property :verbose
     property :yaml_include_root
+    property :fill_empty, default: 0
 
     def initialize(options)
       options[:lokalise_api_token] ||= ENV['LOKALISE_API_TOKEN']
@@ -72,6 +73,7 @@ module Lokalise
           filter: 'translated',
           bundle_filename: '%PROJECT_NAME%-Locale.zip',
           bundle_structure: self.structure,
+          fill_empty: self.fill_empty,
           yaml_include_root: boolean_to_binary[yaml_include_root]
       )
 

--- a/lib/lokalise.rb
+++ b/lib/lokalise.rb
@@ -35,7 +35,7 @@ module Lokalise
     property :language_fallback
     property :quiet
     property :verbose
-    property :filter, default 'translated'
+    property :filter, default: 'translated'
     property :yaml_include_root
     property :export_empty, default: 'skip'
 

--- a/lib/lokalise.rb
+++ b/lib/lokalise.rb
@@ -73,9 +73,10 @@ module Lokalise
           filter: 'translated',
           bundle_filename: '%PROJECT_NAME%-Locale.zip',
           bundle_structure: self.structure,
-          export_empty: "empty",
+          export_empty: self.export_empty,
           yaml_include_root: boolean_to_binary[yaml_include_root]
       )
+      p body.pretty_inspect
 
       fetch_start = Time.now
       response = Excon.post 'https://lokalise.co/api/project/export',

--- a/lib/lokalise.rb
+++ b/lib/lokalise.rb
@@ -73,7 +73,7 @@ module Lokalise
           filter: 'translated',
           bundle_filename: '%PROJECT_NAME%-Locale.zip',
           bundle_structure: self.structure,
-          export_empty: self.export_empty,
+          export_empty: "empty",
           yaml_include_root: boolean_to_binary[yaml_include_root]
       )
 

--- a/lib/lokalise.rb
+++ b/lib/lokalise.rb
@@ -36,7 +36,7 @@ module Lokalise
     property :quiet
     property :verbose
     property :yaml_include_root
-    property :fill_empty, default: 0
+    property :export_empty, default: 'skip'
 
     def initialize(options)
       options[:lokalise_api_token] ||= ENV['LOKALISE_API_TOKEN']
@@ -73,7 +73,7 @@ module Lokalise
           filter: 'translated',
           bundle_filename: '%PROJECT_NAME%-Locale.zip',
           bundle_structure: self.structure,
-          fill_empty: self.fill_empty,
+          export_empty: self.export_empty,
           yaml_include_root: boolean_to_binary[yaml_include_root]
       )
 


### PR DESCRIPTION
## Caveat ##

If export_empty is set to "empty", filter should be changed from "translated" to "nonhidden" in order to get empty values.